### PR TITLE
feat: 구단 일정 API 개발 (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,15 @@ dependencies {
 
     //open feign
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+    // FCM
+    implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.2.0'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
+
+    //Java 8의 날짜/시간 API를 지원을 위한 추가 모듈
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.16.1'
+
+
+
 }
 
 dependencyManagement {

--- a/src/main/java/sejong/team/controller/ScheduleController.java
+++ b/src/main/java/sejong/team/controller/ScheduleController.java
@@ -1,0 +1,36 @@
+package sejong.team.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import sejong.team.global.DataResponse;
+import sejong.team.service.ScheduleService;
+import sejong.team.service.req.CreateScheduleRequestDto;
+import sejong.team.service.res.ViewScheduleResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/team-service")
+public class ScheduleController {
+    private final ScheduleService scheduleService;
+    @PostMapping("/{teamId}/schedules")
+    public DataResponse createSchedule(@PathVariable(name = "teamId") Long teamId,
+                                       @RequestBody CreateScheduleRequestDto createScheduleRequestDto){
+        scheduleService.createSchedule(teamId, createScheduleRequestDto);
+        return new DataResponse();
+    }
+    @GetMapping("/schedules/{scheduleId}")
+    public DataResponse<ViewScheduleResponseDto> viewSchedule(@PathVariable(name = "scheduleId") Long scheduleId){
+        return new DataResponse<>(scheduleService.viewSchedule(scheduleId));
+    }
+    @PutMapping("/schedules/{scheduleId}")
+    public DataResponse acceptSchedule(@PathVariable(name = "scheduleId") Long scheduleId){
+        scheduleService.acceptSchedule(scheduleId);
+        return new DataResponse();
+    }
+
+    @DeleteMapping("/schedules/{scheduleId}")
+    public DataResponse rejectSchedule(@PathVariable(name = "scheduleId") Long scheduleId){
+        scheduleService.deleteSchedule(scheduleId);
+        return new DataResponse();
+    }
+}

--- a/src/main/java/sejong/team/domain/Schedule.java
+++ b/src/main/java/sejong/team/domain/Schedule.java
@@ -1,0 +1,38 @@
+package sejong.team.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "schedule_tb")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Schedule {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @Column(name = "home_team_id")
+    private Long homeTeamId;
+    @Column(name = "away_team_id")
+    private Long awayTeamId;
+    private String place;
+    private Double longitude;
+    private Double latitude;
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+    private String memo;
+    private String title;
+    private Boolean accept;
+
+}

--- a/src/main/java/sejong/team/fcm/FCMConfig.java
+++ b/src/main/java/sejong/team/fcm/FCMConfig.java
@@ -1,0 +1,35 @@
+package sejong.team.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FCMConfig {
+    @Value("${fcm.service-account-file}")
+    private String serviceAccountFilePath;
+
+    /**
+     * 토픽 필요 시 설정
+     */
+    @Value("${fcm.topic-name}")
+    private String topicName;
+    @Value("${fcm.project-id}")
+    private String projectId;
+
+    @PostConstruct
+    public void initialize() throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(serviceAccountFilePath).getInputStream()))
+                .setProjectId(projectId)
+                .build();
+
+        FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/sejong/team/fcm/FCMService.java
+++ b/src/main/java/sejong/team/fcm/FCMService.java
@@ -1,0 +1,93 @@
+package sejong.team.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class FCMService {
+    /**
+     * 토큰 기반 전송 -> 특정 사용자의 디바이스에 개별적인 알림을 전송(특정 한명에게 전송)
+     * @param fcmToken
+     * @param scheduleNotificationDto
+     */
+    public void sendNotificationToToken(String fcmToken,
+                                        ScheduleNotificationDto scheduleNotificationDto) {
+
+        Message message = Message.builder()
+                .setNotification(getnotification())
+                .setToken(fcmToken)
+                .putAllData(getData(scheduleNotificationDto))
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("전송 성공: " + response);
+        } catch (Exception e) {
+            log.info("전송 실패: " + e);
+        }
+    }
+
+    /**
+     * 토픽 기반 전송 ->  구독자들에게 일반적인 알림을 전송(다수에게 전송)
+     * @param topic
+     * @param scheduleNotificationDto
+     */
+    public void sendNotificationToTopic(String topic,
+                                        ScheduleNotificationDto scheduleNotificationDto) {
+
+        Message message = Message.builder()
+                .setNotification(getnotification())
+                .setTopic(topic)
+                .putAllData(getData(scheduleNotificationDto))
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("전송 성공: " + response);
+        } catch (Exception e) {
+            log.info("전송 실패: " + e);
+        }
+    }
+
+    private Notification getnotification(){
+
+        Notification notification = Notification.builder()
+                .setTitle("새로운 일정")
+                .setBody("일정이 생성되었습니다")
+                .build();
+
+        return notification;
+    }
+
+    /**
+     * DatetimeFormat 협의 필요.
+     * @param scheduleNotificationDto
+     * @return
+     */
+    private Map<String,String> getData(ScheduleNotificationDto scheduleNotificationDto){
+        Map<String, String> data = new HashMap<>();
+        data.put("title", scheduleNotificationDto.getTitle());
+        data.put("memo", scheduleNotificationDto.getMemo());
+        data.put("homeTeamName", scheduleNotificationDto.getHomeTeamName());
+        data.put("homeTeamImage", scheduleNotificationDto.getHomeTeamEmblem());
+        data.put("homeTeamUniqueNumber", scheduleNotificationDto.getHomeTeamUniqueNumber());
+        data.put("awayTeamName", scheduleNotificationDto.getAwayTeamName());
+        data.put("awayTeamImage", scheduleNotificationDto.getAwayTeamEmblem());
+        data.put("awayTeamUniqueNumber", scheduleNotificationDto.getAwayTeamUniqueNumber());
+        data.put("startTime", scheduleNotificationDto.getStartTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        data.put("endTime", scheduleNotificationDto.getEndTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        data.put("place", scheduleNotificationDto.getPlace());
+        data.put("longitude", scheduleNotificationDto.getLongitude().toString());
+        data.put("latitude", scheduleNotificationDto.getLatitude().toString());
+
+        return data;
+    }
+}

--- a/src/main/java/sejong/team/fcm/ScheduleNotificationDto.java
+++ b/src/main/java/sejong/team/fcm/ScheduleNotificationDto.java
@@ -1,0 +1,24 @@
+package sejong.team.fcm;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScheduleNotificationDto {
+    private String title;
+    private String memo;
+    private String homeTeamName;
+    private String homeTeamEmblem;
+    private String homeTeamUniqueNumber;
+    private String awayTeamName;
+    private String awayTeamEmblem;
+    private String awayTeamUniqueNumber;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String place;
+    private Double longitude;
+    private Double latitude;
+}

--- a/src/main/java/sejong/team/global/DataResponse.java
+++ b/src/main/java/sejong/team/global/DataResponse.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 @Getter
 public class DataResponse<T> extends BaseResponse{
     private T data;
+    public DataResponse() {
+        super();
+    }
 
     public DataResponse(T data) {
         super();

--- a/src/main/java/sejong/team/global/GlobalExceptionHandler.java
+++ b/src/main/java/sejong/team/global/GlobalExceptionHandler.java
@@ -1,7 +1,17 @@
 package sejong.team.global;
 
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<BaseResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
+        BaseResponse response = new BaseResponse(400, "E100", ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/sejong/team/global/MessageUtils.java
+++ b/src/main/java/sejong/team/global/MessageUtils.java
@@ -3,4 +3,6 @@ package sejong.team.global;
 public class MessageUtils {
     public static final String SUCCESS = "SUCCESS";
     public static final String FAIL = "FAIL";
+    public static final String TEAM_NOT_FOUND = "TEAM NOT FOUND";
+    public static final String SCHEDULE_NOT_FOUND = "SCHEDULE NOT FOUND";
 }

--- a/src/main/java/sejong/team/repository/ScheduleRepository.java
+++ b/src/main/java/sejong/team/repository/ScheduleRepository.java
@@ -1,0 +1,17 @@
+package sejong.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sejong.team.domain.Schedule;
+
+public interface ScheduleRepository extends JpaRepository<Schedule,Long> {
+    @Modifying
+    @Query("UPDATE schedule_tb s SET s.accept = TRUE WHERE s.id = :scheduleId")
+    void updateAccept(@Param("scheduleId") Long scheduleId);
+
+    @Modifying
+    @Query("DELETE FROM schedule_tb s WHERE s.id = :scheduleId")
+    void deleteById(@Param("scheduleId") Long scheduleId);
+}

--- a/src/main/java/sejong/team/service/ScheduleService.java
+++ b/src/main/java/sejong/team/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package sejong.team.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -7,6 +8,7 @@ import sejong.team.domain.Schedule;
 import sejong.team.domain.Team;
 import sejong.team.fcm.FCMService;
 import sejong.team.fcm.ScheduleNotificationDto;
+import sejong.team.global.MessageUtils;
 import sejong.team.repository.ScheduleRepository;
 import sejong.team.repository.TeamRepository;
 import sejong.team.service.req.CreateScheduleRequestDto;
@@ -34,8 +36,11 @@ public class ScheduleService {
                 .accept(false)
                 .build();
 
-        Team homeTeam = teamRepository.findById(homeTeamId).get();
-        Team awayTeam = teamRepository.findById(createScheduleRequestDto.getAwayTeamId()).get();
+        Team homeTeam = teamRepository.findById(homeTeamId)
+                .orElseThrow(() -> new EntityNotFoundException(MessageUtils.TEAM_NOT_FOUND));
+
+        Team awayTeam = teamRepository.findById(createScheduleRequestDto.getAwayTeamId())
+                .orElseThrow(() -> new EntityNotFoundException(MessageUtils.TEAM_NOT_FOUND));
 
         ScheduleNotificationDto scheduleNotificationDto = ScheduleNotificationDto.builder()
                 .title(createScheduleRequestDto.getTitle())
@@ -57,10 +62,14 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
     }
     public ViewScheduleResponseDto viewSchedule(Long scheduleId){
-        Schedule schedule = scheduleRepository.findById(scheduleId).get();
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException(MessageUtils.SCHEDULE_NOT_FOUND));
 
-        Team homeTeam = teamRepository.findById(schedule.getHomeTeamId()).get();
-        Team awayTeam = teamRepository.findById(schedule.getAwayTeamId()).get();
+        Team homeTeam = teamRepository.findById(schedule.getHomeTeamId())
+                .orElseThrow(() -> new EntityNotFoundException(MessageUtils.TEAM_NOT_FOUND));
+
+        Team awayTeam = teamRepository.findById(schedule.getAwayTeamId())
+                .orElseThrow(() -> new EntityNotFoundException(MessageUtils.TEAM_NOT_FOUND));
 
         ViewScheduleResponseDto viewScheduleResponseDto = ViewScheduleResponseDto.builder()
                 .title(schedule.getTitle())

--- a/src/main/java/sejong/team/service/ScheduleService.java
+++ b/src/main/java/sejong/team/service/ScheduleService.java
@@ -1,0 +1,92 @@
+package sejong.team.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sejong.team.domain.Schedule;
+import sejong.team.domain.Team;
+import sejong.team.fcm.FCMService;
+import sejong.team.fcm.ScheduleNotificationDto;
+import sejong.team.repository.ScheduleRepository;
+import sejong.team.repository.TeamRepository;
+import sejong.team.service.req.CreateScheduleRequestDto;
+import sejong.team.service.res.ViewScheduleResponseDto;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+    private final ScheduleRepository scheduleRepository;
+    private final TeamRepository teamRepository;
+    private final FCMService fcmService;
+    @Transactional
+    public void createSchedule(Long homeTeamId,
+                               CreateScheduleRequestDto createScheduleRequestDto){
+
+        Schedule schedule = Schedule.builder()
+                .homeTeamId(homeTeamId)
+                .title(createScheduleRequestDto.getTitle())
+                .memo(createScheduleRequestDto.getMemo())
+                .startTime(createScheduleRequestDto.getStartTime())
+                .endTime(createScheduleRequestDto.getEndTime())
+                .place(createScheduleRequestDto.getPlace())
+                .longitude(createScheduleRequestDto.getLongitude())
+                .latitude(createScheduleRequestDto.getLatitude())
+                .accept(false)
+                .build();
+
+        Team homeTeam = teamRepository.findById(homeTeamId).get();
+        Team awayTeam = teamRepository.findById(createScheduleRequestDto.getAwayTeamId()).get();
+
+        ScheduleNotificationDto scheduleNotificationDto = ScheduleNotificationDto.builder()
+                .title(createScheduleRequestDto.getTitle())
+                .memo(createScheduleRequestDto.getMemo())
+                .homeTeamName(homeTeam.getName())
+                .homeTeamUniqueNumber(homeTeam.getUniqueNum())
+                .homeTeamEmblem(homeTeam.getEmblem())
+                .awayTeamName(awayTeam.getName())
+                .awayTeamUniqueNumber(awayTeam.getUniqueNum())
+                .awayTeamEmblem(awayTeam.getEmblem())
+                .startTime(createScheduleRequestDto.getStartTime())
+                .endTime(createScheduleRequestDto.getEndTime())
+                .place(createScheduleRequestDto.getPlace())
+                .longitude(createScheduleRequestDto.getLongitude())
+                .latitude(createScheduleRequestDto.getLatitude())
+                .build();
+
+        fcmService.sendNotificationToToken(createScheduleRequestDto.getFcmToken(), scheduleNotificationDto);
+        scheduleRepository.save(schedule);
+    }
+    public ViewScheduleResponseDto viewSchedule(Long scheduleId){
+        Schedule schedule = scheduleRepository.findById(scheduleId).get();
+
+        Team homeTeam = teamRepository.findById(schedule.getHomeTeamId()).get();
+        Team awayTeam = teamRepository.findById(schedule.getAwayTeamId()).get();
+
+        ViewScheduleResponseDto viewScheduleResponseDto = ViewScheduleResponseDto.builder()
+                .title(schedule.getTitle())
+                .memo(schedule.getMemo())
+                .homeTeamName(homeTeam.getName())
+                .homeTeamUniqueNumber(homeTeam.getUniqueNum())
+                .homeTeamEmblem(homeTeam.getEmblem())
+                .awayTeamName(awayTeam.getName())
+                .awayTeamUniqueNumber(awayTeam.getUniqueNum())
+                .awayTeamEmblem(awayTeam.getEmblem())
+                .startTime(schedule.getStartTime())
+                .endTime(schedule.getEndTime())
+                .place(schedule.getPlace())
+                .longitude(schedule.getLongitude())
+                .latitude(schedule.getLatitude())
+                .build();
+
+        return viewScheduleResponseDto;
+    }
+    @Transactional
+    public void acceptSchedule(Long scheduleId){
+        scheduleRepository.updateAccept(scheduleId);
+    }
+
+    @Transactional
+    public void deleteSchedule(Long scheduleId){
+        scheduleRepository.deleteById(scheduleId);
+    }
+}

--- a/src/main/java/sejong/team/service/req/CreateScheduleRequestDto.java
+++ b/src/main/java/sejong/team/service/req/CreateScheduleRequestDto.java
@@ -1,0 +1,29 @@
+package sejong.team.service.req;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * @JsonDeserialize
+ * Jackson이 사용할 Builder 클래스를 명시. Jackson이 Builder 클래스를 사용하여 객체를 생성하도록 한다.
+ */
+@Getter
+@Builder
+@JsonDeserialize(builder = CreateScheduleRequestDto.CreateScheduleRequestDtoBuilder.class)
+public class CreateScheduleRequestDto {
+    private String title;
+    private String memo;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String place;
+    private Long awayTeamId;
+    private Double longitude;
+    private Double latitude;
+    private String fcmToken;
+
+
+
+}

--- a/src/main/java/sejong/team/service/res/ViewScheduleResponseDto.java
+++ b/src/main/java/sejong/team/service/res/ViewScheduleResponseDto.java
@@ -1,0 +1,24 @@
+package sejong.team.service.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ViewScheduleResponseDto {
+    private String title;
+    private String memo;
+    private String homeTeamName;
+    private String homeTeamEmblem;
+    private String homeTeamUniqueNumber;
+    private String awayTeamName;
+    private String awayTeamEmblem;
+    private String awayTeamUniqueNumber;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String place;
+    private Double longitude;
+    private Double latitude;
+}

--- a/src/test/java/sejong/team/controller/ScheduleControllerTest.java
+++ b/src/test/java/sejong/team/controller/ScheduleControllerTest.java
@@ -1,0 +1,101 @@
+package sejong.team.controller;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import sejong.team.service.ScheduleService;
+import sejong.team.service.req.CreateScheduleRequestDto;
+import sejong.team.service.res.ViewScheduleResponseDto;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+public class ScheduleControllerTest {
+    @Mock
+    private ScheduleService scheduleService;
+
+    @InjectMocks
+    private ScheduleController scheduleController;
+
+    private MockMvc mockMvc;
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(scheduleController).build();
+    }
+
+    @Test
+    @DisplayName("일정 생성 API 테스트")
+    public void testCreateSchedule() throws Exception {
+        Long teamId = 1L;
+        CreateScheduleRequestDto createScheduleRequestDto = CreateScheduleRequestDto.builder()
+                .title("팀 매치")
+                .memo("3시에 시작합니다")
+                .startTime(LocalDateTime.parse("2023-09-01T15:00:00"))
+                .endTime(LocalDateTime.parse("2023-09-01T17:00:00"))
+                .place("지역 축구장")
+                .longitude(127.123456)
+                .latitude(37.123456)
+                .awayTeamId(2L)
+                .fcmToken("fcm_token_example")
+                .build();
+
+        // JSON 문자열로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        String jsonContent = objectMapper.writeValueAsString(createScheduleRequestDto);
+
+        mockMvc.perform(post("/api/team-service/" + teamId + "/schedules")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().isOk());
+
+        verify(scheduleService).createSchedule(eq(teamId), any(CreateScheduleRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("일정 상세 뷰 API 테스트")
+    public void testViewSchedule() throws Exception {
+        Long scheduleId = 1L;
+        when(scheduleService.viewSchedule(scheduleId)).thenReturn(ViewScheduleResponseDto.builder().build());
+
+        mockMvc.perform(get("/api/team-service/schedules/" + scheduleId))
+                .andExpect(status().isOk());
+
+        verify(scheduleService).viewSchedule(scheduleId);
+    }
+
+    @Test
+    @DisplayName("푸시알림 수락 API 테스트")
+    public void testAcceptSchedule() throws Exception {
+        Long scheduleId = 1L;
+
+        mockMvc.perform(put("/api/team-service/schedules/" + scheduleId))
+                .andExpect(status().isOk());
+
+        verify(scheduleService).acceptSchedule(scheduleId);
+    }
+
+    @Test
+    @DisplayName("푸시알림 거절 API 테스트")
+    public void testRejectSchedule() throws Exception {
+        Long scheduleId = 1L;
+
+        mockMvc.perform(delete("/api/team-service/schedules/" + scheduleId))
+                .andExpect(status().isOk());
+
+        verify(scheduleService).deleteSchedule(scheduleId);
+    }
+}

--- a/src/test/java/sejong/team/service/ScheduleServiceTest.java
+++ b/src/test/java/sejong/team/service/ScheduleServiceTest.java
@@ -1,0 +1,103 @@
+package sejong.team.service;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sejong.team.domain.Schedule;
+import sejong.team.domain.Team;
+import sejong.team.fcm.FCMService;
+import sejong.team.fcm.ScheduleNotificationDto;
+import sejong.team.repository.ScheduleRepository;
+import sejong.team.repository.TeamRepository;
+import sejong.team.service.req.CreateScheduleRequestDto;
+import sejong.team.service.res.ViewScheduleResponseDto;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class ScheduleServiceTest {
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private FCMService fcmService;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("일정 생성 테스트")
+    public void testCreateSchedule() {
+        Long homeTeamId = 1L;
+        CreateScheduleRequestDto createScheduleRequestDto = CreateScheduleRequestDto.builder()
+                .title("축구 경기")
+                .memo("15:00에 시작하는 친선 경기")
+                .startTime(LocalDateTime.of(2023, 9, 10, 15, 0))
+                .endTime(LocalDateTime.of(2023, 9, 10, 17, 0))
+                .place("서울시 광진구 군자동 28-2")
+                .awayTeamId(2L)
+                .longitude(127.1234)
+                .latitude(37.5678)
+                .fcmToken("test_token")
+                .build();
+
+        Team mockHomeTeam = new Team();
+        Team mockAwayTeam = new Team();
+
+        when(teamRepository.findById(homeTeamId)).thenReturn(Optional.of(mockHomeTeam));
+        when(teamRepository.findById(createScheduleRequestDto.getAwayTeamId())).thenReturn(Optional.of(mockAwayTeam));
+
+        scheduleService.createSchedule(homeTeamId, createScheduleRequestDto);
+
+        verify(scheduleRepository).save(any(Schedule.class));
+        verify(fcmService).sendNotificationToToken(eq(createScheduleRequestDto.getFcmToken()),
+                any(ScheduleNotificationDto.class));
+    }
+
+    @Test
+    @DisplayName("일정 상세 뷰 테스트")
+    public void testViewSchedule() {
+        Long scheduleId = 1L;
+        Schedule mockSchedule = new Schedule();
+        Team mockHomeTeam = new Team();
+        Team mockAwayTeam = new Team();
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(mockSchedule));
+        when(teamRepository.findById(mockSchedule.getHomeTeamId())).thenReturn(Optional.of(mockHomeTeam));
+        when(teamRepository.findById(mockSchedule.getAwayTeamId())).thenReturn(Optional.of(mockAwayTeam));
+
+        ViewScheduleResponseDto response = scheduleService.viewSchedule(scheduleId);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    @DisplayName("푸시알림 수락 테스트")
+    public void testAcceptSchedule() {
+        Long scheduleId = 1L;
+
+        scheduleService.acceptSchedule(scheduleId);
+
+        verify(scheduleRepository).updateAccept(scheduleId);
+    }
+
+    @Test
+    @DisplayName("푸시알림 거절 테스트")
+    public void testDeleteSchedule() {
+        Long scheduleId = 1L;
+
+        scheduleService.deleteSchedule(scheduleId);
+
+        verify(scheduleRepository).deleteById(scheduleId);
+    }
+}


### PR DESCRIPTION
아직 프론트단과 FCM 논의가 안되있어서 테스트하지 못한 상태입니다. 
논의 후 수정 및 테스트하여 완성 예정입니다. 

- [X] 일정 생성 API 로직 개발
- [X] 일정 조회 API 로직 개발
- [X] 상대편 푸시알림(FCM)을 통한 일정 수락 API 개발
- [X] 상대편 푸시알림(FCM)을 통한 일정 거절 API 개발