### PR TITLE
[Feature] 팀 검색 API

### DIFF
--- a/src/main/java/sejong/team/common/client/UserServiceClient.java
+++ b/src/main/java/sejong/team/common/client/UserServiceClient.java
@@ -8,6 +8,6 @@ import sejong.team.common.client.dto.SizeUserTeamResponse;
 
 @FeignClient(name = "user-service")
 public interface UserServiceClient {
-    @GetMapping("/api/user-service/users/teams/{teamId}")
+    @GetMapping("/api/user-service/users/teams/{teamId}/size")
     ResponseEntity<SizeUserTeamResponse> countUsersInTeam(@PathVariable(value = "teamId") Long teamId);
 }

--- a/src/main/java/sejong/team/controller/TeamController.java
+++ b/src/main/java/sejong/team/controller/TeamController.java
@@ -3,10 +3,11 @@ package sejong.team.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import sejong.team.dto.TeamDto;
-import sejong.team.global.BaseResponse;
 import sejong.team.global.DataResponse;
 import sejong.team.service.TeamService;
+import sejong.team.service.req.SearchTeamInfoRequestDto;
 import sejong.team.service.res.CreateTeamResponseVO;
+import sejong.team.service.res.SearchTeamInfoResponseDto;
 import sejong.team.service.res.SearchTeamResponseDto;
 import sejong.team.service.res.TeamBaseInfoResponseDto;
 
@@ -18,17 +19,28 @@ import java.util.List;
 @RequestMapping("/api/team-service")
 public class TeamController {
     private final TeamService teamService;
+
     @GetMapping("/teams/{teamId}")
     public DataResponse<TeamBaseInfoResponseDto> findTeamBaseInfo(@PathVariable Long teamId) {
         return new DataResponse<>(teamService.findTeamInfo(teamId));
     }
+
     @PostMapping("/teams")
     public DataResponse<CreateTeamResponseVO> createTeam(@ModelAttribute TeamDto teamDto) throws IOException {
         return new DataResponse<>(teamService.createTeam(teamDto));
     }
+
     @GetMapping("/teams")
-    public DataResponse<List<SearchTeamResponseDto>> findAllTeams(){
+    public DataResponse<List<SearchTeamResponseDto>> findAllTeams() {
         return new DataResponse<>(teamService.findAllTeams());
+    }
+
+    @GetMapping("/team/search")
+    public DataResponse<List<SearchTeamInfoResponseDto>> searchTeamInfo(@RequestParam(name = "search") String search) {
+        List<SearchTeamInfoResponseDto> responseDtos = teamService.searchTeamInfo(SearchTeamInfoRequestDto.builder()
+                .search(search)
+                .build());
+        return new DataResponse<>(responseDtos);
     }
 
 }

--- a/src/main/java/sejong/team/repository/TeamRepository.java
+++ b/src/main/java/sejong/team/repository/TeamRepository.java
@@ -1,8 +1,8 @@
 package sejong.team.repository;
 
-import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sejong.team.domain.Team;
 
 import java.util.List;
@@ -11,6 +11,6 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team,Long> {
     Optional<Team> findById(Long teamId);
 
-    @Query("select t from team_tb as t where t.uniqueNum=:conditions or t.name=:conditions")
-    List<Team> findAllByCondition(@Param(value = "conditions") String conditions);
+    @Query("select t from team_tb as t where t.uniqueNum=:search or t.name=:search")
+    List<Team> findAllByCondition(@Param(value = "search") String search);
 }

--- a/src/main/java/sejong/team/service/TeamService.java
+++ b/src/main/java/sejong/team/service/TeamService.java
@@ -1,6 +1,5 @@
 package sejong.team.service;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +10,9 @@ import sejong.team.common.client.dto.SizeUserTeamResponse;
 import sejong.team.domain.Team;
 import sejong.team.dto.TeamDto;
 import sejong.team.repository.TeamRepository;
+import sejong.team.service.req.SearchTeamInfoRequestDto;
 import sejong.team.service.res.CreateTeamResponseVO;
+import sejong.team.service.res.SearchTeamInfoResponseDto;
 import sejong.team.service.res.SearchTeamResponseDto;
 import sejong.team.service.res.TeamBaseInfoResponseDto;
 
@@ -71,12 +72,17 @@ public class TeamService {
         return responseDtos;
 
     }
-    /*
-    public List<SearchTeamInfoResponseDto> searchTeamInfoByNameOrCode(SearchTeamInfoRequestDto requestDto) {
-        List<Team> allTeamByCond = teamRepository.findAllByCondition(requestDto.getSearchCond());
-        allTeamByCond.stream()
-        allTeamByCond.stream().map(team -> SearchTeamInfoResponseDto.of(
-            team.getId(),team.getName(),team.getEmblem(),,team.getUnique_num()
-        ))
-    }*/
+
+    public List<SearchTeamInfoResponseDto> searchTeamInfo(SearchTeamInfoRequestDto requestDto) {
+        List<Team> searchTeam = teamRepository.findAllByCondition(requestDto.getSearch());
+        return searchTeam.stream().map(
+                team ->
+                        SearchTeamInfoResponseDto.builder()
+                                .totalMemberCnt(userServiceClient.countUsersInTeam(team.getId()).getBody().getSize())
+                                .teamName(team.getName())
+                                .teamId(team.getId())
+                                .uniqueNum(team.getUniqueNum())
+                                .emblem(team.getEmblem())
+                                .build()).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/sejong/team/service/req/SearchTeamInfoRequestDto.java
+++ b/src/main/java/sejong/team/service/req/SearchTeamInfoRequestDto.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SearchTeamInfoRequestDto {
-    private String searchCond;
+    private String search;
     public static SearchTeamInfoRequestDto of(String searchParam){
         return SearchTeamInfoRequestDto.builder()
-                .searchCond(searchParam)
+                .search(searchParam)
                 .build();
     }
 }


### PR DESCRIPTION
### 생성기능
- 팀 검색 기능 
  - 하나의 쿼리파라미터로 팀명/유니크키 탐색하여 팀 정보 조회
<img src="https://github.com/FootballManagementMSA/Team-Server/assets/74135929/92ffb144-f0e8-4980-8d3d-6bda56928fcd" width="200" height="200">

### 기존 코드 수정사항
- user-service에서 사용자수 조회하는 Feign uri 수정