### PR TITLE
[Feature] 일정 삭제 스케쥴링 로직 개발

### DIFF
--- a/src/main/java/sejong/team/controller/ScheduleCleanupController.java
+++ b/src/main/java/sejong/team/controller/ScheduleCleanupController.java
@@ -1,0 +1,20 @@
+package sejong.team.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.team.global.DataResponse;
+import sejong.team.scheduler.ScheduleCleanupTask;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/team-service")
+public class ScheduleCleanupController {
+    private final ScheduleCleanupTask scheduleCleanupTask;
+    @GetMapping("/cleanup")
+    public DataResponse triggerCleanup() {
+        scheduleCleanupTask.cleanUpExpiredSchedules();
+        return new DataResponse();
+    }
+}

--- a/src/main/java/sejong/team/domain/Squad.java
+++ b/src/main/java/sejong/team/domain/Squad.java
@@ -22,6 +22,4 @@ public class Squad {
     private Long scheduleId;
     @Column(name = "team_id")
     private Long teamId;
-    @Column(name = "user_squad_id")
-    private Long userSquadId;
 }

--- a/src/main/java/sejong/team/repository/ScheduleRepository.java
+++ b/src/main/java/sejong/team/repository/ScheduleRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sejong.team.domain.Schedule;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ScheduleRepository extends JpaRepository<Schedule,Long> {
     @Modifying
     @Query("UPDATE schedule_tb s SET s.accept = TRUE WHERE s.id = :scheduleId")
@@ -14,4 +17,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule,Long> {
     @Modifying
     @Query("DELETE FROM schedule_tb s WHERE s.id = :scheduleId")
     void deleteById(@Param("scheduleId") Long scheduleId);
+
+    List<Schedule> findAllByEndTimeBefore(LocalDateTime now);
 }

--- a/src/main/java/sejong/team/repository/SquadRepository.java
+++ b/src/main/java/sejong/team/repository/SquadRepository.java
@@ -5,10 +5,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sejong.team.domain.Squad;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SquadRepository extends JpaRepository<Squad,Long> {
     @Query("SELECT s FROM squad_tb s WHERE s.scheduleId = :scheduleId AND s.teamId = :teamId")
     Optional<Squad> findSquadByScheduleIdAndTeamId(@Param("scheduleId") Long scheduleId,
                                                    @Param("teamId") Long teamId);
+
+    List<Squad> findByScheduleId(Long scheduleId);
+    void deleteByScheduleId(Long scheduleId);
+
 }

--- a/src/main/java/sejong/team/repository/UserSquadRepository.java
+++ b/src/main/java/sejong/team/repository/UserSquadRepository.java
@@ -20,4 +20,10 @@ public interface UserSquadRepository extends JpaRepository<UserSquad,Long> {
                                    @Param("squadId") Long squadId,
                                    @Param("xCoordinate") Double xCoordinate,
                                    @Param("yCoordinate") Double yCoordinate);
+
+    /**
+     * 벌크연산 - squad_id가 squadIds 리스트에 있는 ID 중 하나라도 일치하는 모든 UserSquad 행을 삭제
+     * @param squadIds
+     */
+    void deleteBySquadIdIn(List<Long> squadIds);
 }

--- a/src/main/java/sejong/team/scheduler/ScheduleCleanupTask.java
+++ b/src/main/java/sejong/team/scheduler/ScheduleCleanupTask.java
@@ -1,0 +1,50 @@
+package sejong.team.scheduler;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import sejong.team.domain.Schedule;
+import sejong.team.domain.Squad;
+import sejong.team.repository.ScheduleRepository;
+import sejong.team.repository.SquadRepository;
+import sejong.team.repository.UserSquadRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleCleanupTask {
+    private final ScheduleRepository scheduleRepository;
+    private final UserSquadRepository userSquadRepository;
+    private final SquadRepository squadRepository;
+
+    // 매일 자정에 실행되도록 설정 (cron = "0 0 0 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void cleanUpExpiredSchedules() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Schedule> expiredSchedules = scheduleRepository.findAllByEndTimeBefore(now);
+
+        expiredSchedules.forEach(schedule -> {
+            // 해당 Schedule과 연결된 모든 Squad 찾기
+            List<Squad> relatedSquads = squadRepository.findByScheduleId(schedule.getId());
+            // Squad ID 리스트 추출 (홈팀, 어웨이팀 두 개의 Squad ID 획득.)
+            List<Long> squadIds = relatedSquads.stream().map(Squad::getId).collect(Collectors.toList());
+            // UserSquad 레코드 삭제 -> 벌크연산 사용
+            if (!squadIds.isEmpty()) {
+                userSquadRepository.deleteBySquadIdIn(squadIds);
+            }
+            // Squad 테이블 내 ScheduleId가 일치하는 행 삭제(두 개 삭제 -> 홈팀, 어웨이팀)
+            squadRepository.deleteByScheduleId(schedule.getId());
+            // Schedule 레코드 삭제
+            scheduleRepository.delete(schedule);
+            // 로깅
+            log.info("만료된 Schedule ID {} 와 관련된 squad, user-squad 데이터 삭제 완료", schedule.getId());
+        });
+    }
+}


### PR DESCRIPTION
매일 자정 기준으로 경기의 끝나는 시간이 지나 있으면, 관련 데이터 삭제 로직을 개발했습니다.
테스트용 컨트롤러를 하나 작성하여 테스트 완료했고, 서버 배포 시 테스트 컨트롤러는 삭제 예정입니다.