### PR TITLE
[Refactor] 데이터 일괄 Delete 쿼리문 개선 #28

### DIFF
--- a/src/main/java/sejong/team/repository/UserSquadRepository.java
+++ b/src/main/java/sejong/team/repository/UserSquadRepository.java
@@ -28,5 +28,7 @@ public interface UserSquadRepository extends JpaRepository<UserSquad,Long> {
      */
     void deleteBySquadIdIn(List<Long> squadIds);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM user_squad_tb us WHERE us.userId = :userId")
+    void deleteAllByUserIds(Long userId);
 }

--- a/src/main/java/sejong/team/service/SquadService.java
+++ b/src/main/java/sejong/team/service/SquadService.java
@@ -87,6 +87,6 @@ public class SquadService {
 
     @Transactional
     public void deleteUserSqaud(Long userId) {
-        userSquadRepository.deleteAllByUserId(userId);
+        userSquadRepository.deleteAllByUserIds(userId);
     }
 }


### PR DESCRIPTION
## 데이터 일괄 DELETE 쿼리 개선
Kafka 연동을 통해 TEAM-SERVER의 UserSquad를 삭제하는 부분에서 JpaRepository의 deleteAllByUserId 메서드를 정의하여 사용하였다.
```
@Transactional
public void deleteUserSqaud(Long userId) {
    userSquadRepository.deleteAllByUserId(userId);
}
```

<br>

그러나 내부적으로 repository.deleteAll 메서드는 다음과 같은 동작을 진행한다.
```
/*
 * (non-Javadoc)
 * @see org.springframework.data.repository.Repository#deleteAll()
 */
@Override
@Transactional
public void deleteAll() {

	for (T element : findAll()) {
		delete(element);
	}
}
```
JpaRepository에서 제공하는 deleteByXXX 등의 메소드를 이용하는 삭제는 단건이 아닌 여러건을 삭제하더라도 먼저 조회를 하고 그 결과로 얻은 엔티티 데이터를 1건씩 삭제한다는 것이다. 즉, 제가 만약 1억건 중 50만건을 삭제한다고 하면 50만건을 먼저 조회후 건건으로 삭제한다는 것이다.

<br>

## 해결방법
### deleteAllByUserIds
```
@Modifying
@Query("DELETE FROM user_squad_tb us WHERE us.userId = :userId")
void deleteAllByUserIds(Long userId);
```
직접 작성한 삭제쿼리는 일괄 삭제 쿼리가 발생한다.
```sql
delete 
from
    user_sqaud_tb
where
    user_id = 1
```